### PR TITLE
Now support for max value of repetitions with the param repeat.

### DIFF
--- a/scripts/lessonPage.js
+++ b/scripts/lessonPage.js
@@ -82,7 +82,12 @@ window.addEventListener("LessonStatusChanged", async function (e) {
             break;
 
         case "END_CAROUSEL":
-            if (document.location.search.includes("repeat")) { await sleep(); location.reload() };
+            const urlObject = new URL(document.location);
+            if (urlObject.search.includes("repeat")) { 
+                const value = urlObject.searchParams.get("repeat");
+                if(!value || isNaN(Number(value))){ await sleep(); location.reload() };
+                if(Number(value) > 0){ await sleep(); location.assign(location.pathname + "?autosolve&repeat=" + (Number(value) - 1)) };
+            };
             break;
 
         default:


### PR DESCRIPTION
By using "repeat" flag in the url, the extension will reload the lesson page when possible. Sometimes, it is useful to be able to stop after some repetition.

This PR adds the ability to stop autosolving after a fixed number of repetitions.
